### PR TITLE
Performance optimizations and bug fixes

### DIFF
--- a/CoffReader.Tests/CoffReader.Tests.csproj
+++ b/CoffReader.Tests/CoffReader.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CoffReader.Tests/CoffReader.Tests.csproj
+++ b/CoffReader.Tests/CoffReader.Tests.csproj
@@ -14,4 +14,13 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Samples/**/*.o">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Samples/**/*.obj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/CoffReader.Tests/DumpSampleFiles.cs
+++ b/CoffReader.Tests/DumpSampleFiles.cs
@@ -2,7 +2,7 @@
 
 namespace CoffReader.Tests
 {
-    public class Class1
+    public class DumpSampleFiles
     {
         [Test]
         [TestCase(@"cygwin-x64/cyginvokezlibversion_dll_d000000.o")]
@@ -11,7 +11,6 @@ namespace CoffReader.Tests
         [TestCase(@"cygwin-x64/cyginvokezlibversion_dll_d000003.o")]
         [TestCase(@"cygwin-x64/cyginvokezlibversion_dll_d000004.o")]
         [TestCase(@"cygwin-x64/invoke.cpp.o")]
-        [TestCase(@"mingw-x86/invoke.cpp.obj")]
         [TestCase(@"mingw-x86/libinvokezlibversion_dll_d000000.o")]
         [TestCase(@"mingw-x86/libinvokezlibversion_dll_d000001.o")]
         [TestCase(@"mingw-x86/libinvokezlibversion_dll_d000002.o")]
@@ -37,10 +36,7 @@ namespace CoffReader.Tests
         }
 
         private static string ResolvePath(string path) => Path.Combine(
-            TestContext.CurrentContext.WorkDirectory,
-            "..",
-            "..",
-            "..",
+            TestContext.CurrentContext.TestDirectory,
             "Samples",
             path
         );

--- a/CoffReader.Tests/DumpSampleFiles.cs
+++ b/CoffReader.Tests/DumpSampleFiles.cs
@@ -18,7 +18,7 @@ namespace CoffReader.Tests
         {
             var objFileBytes = File.ReadAllBytes(ResolvePath(objFile));
 
-            var parsed = CoffParser.Parse(objFileBytes);
+            var parsed = CoffParser.Parse(objFileBytes, true);
 
             parsed.Sections
                 .ToList()

--- a/CoffReader.Tests/DumpSampleFiles.cs
+++ b/CoffReader.Tests/DumpSampleFiles.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 
 namespace CoffReader.Tests
 {
@@ -31,7 +31,7 @@ namespace CoffReader.Tests
             parsed.Symbols
                 .ToList()
                 .ForEach(
-                    it => Console.WriteLine($"0x{it.Value:X8} {it.SectionNumber,3} {it.SymbolType,2} {it.StorageClass} {it.NumAux} {it.Name} ")
+                    it => Console.WriteLine($"0x{it.Value:X8} {it.SectionNumber,3} {it.SymbolType,2} {it.StorageClass} {it.AuxiliaryRecords.Count} {it.Name} ")
                 );
         }
 

--- a/CoffReader/CoffHeader.cs
+++ b/CoffReader/CoffHeader.cs
@@ -9,6 +9,6 @@ internal record CoffHeader(
     ushort OptionalHeaderSize,
     ushort Flags)
 {
-    public int SectionTablePosition => 20;
+    public int SectionTablePosition => 20 + OptionalHeaderSize;
     public int StringTablePosition => (int) (SymbolTablePosition + 18 * NumSymbols);
 }

--- a/CoffReader/CoffHeader.cs
+++ b/CoffReader/CoffHeader.cs
@@ -1,0 +1,14 @@
+﻿namespace CoffReader;
+
+internal record CoffHeader(
+    ushort Magic,
+    ushort NumSections,
+    uint Timestamp,
+    int SymbolTablePosition,
+    uint NumSymbols,
+    ushort OptionalHeaderSize,
+    ushort Flags)
+{
+    public int SectionTablePosition => 20;
+    public int StringTablePosition => (int) (SymbolTablePosition + 18 * NumSymbols);
+}

--- a/CoffReader/CoffParsed.cs
+++ b/CoffReader/CoffParsed.cs
@@ -1,15 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace CoffReader;
 
-public class CoffParsed
+public record CoffParsed(ushort Magic, uint Timestamp, ushort Flags)
 {
-    public ushort Magic { get; set; }
-    public uint Timestamp { get; set; }
-    public ushort Flags { get; set; }
-
-    public List<CoffSymbol> Symbols { get; set; } = new List<CoffSymbol>();
-    public List<CoffSection> Sections { get; set; } = new List<CoffSection>();
+    public IReadOnlyList<CoffSymbol> Symbols { get; init; } = Array.Empty<CoffSymbol>();
+    public IReadOnlyList<CoffSection> Sections { get; init; } = Array.Empty<CoffSection>();
 
     public const ushort I386MAGIC = 0x14c;
     public const ushort AMD64MAGIC = 0x8664;

--- a/CoffReader/CoffParsed.cs
+++ b/CoffReader/CoffParsed.cs
@@ -1,21 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
-namespace CoffReader
+namespace CoffReader;
+
+public class CoffParsed
 {
-    public class CoffParsed
-    {
-        public ushort Magic { get; set; }
-        public uint Timestamp { get; set; }
-        public ushort Flags { get; set; }
+    public ushort Magic { get; set; }
+    public uint Timestamp { get; set; }
+    public ushort Flags { get; set; }
 
-        public List<CoffSymbol> Symbols { get; set; } = new List<CoffSymbol>();
-        public List<CoffSection> Sections { get; set; } = new List<CoffSection>();
+    public List<CoffSymbol> Symbols { get; set; } = new List<CoffSymbol>();
+    public List<CoffSection> Sections { get; set; } = new List<CoffSection>();
 
-        public const ushort I386MAGIC = 0x14c;
-        public const ushort AMD64MAGIC = 0x8664;
-    }
+    public const ushort I386MAGIC = 0x14c;
+    public const ushort AMD64MAGIC = 0x8664;
 }

--- a/CoffReader/CoffParser.cs
+++ b/CoffReader/CoffParser.cs
@@ -40,20 +40,18 @@ public class CoffParser
             for (int idx = 0; idx < header.NumSections; idx++)
             {
                 var secTabSpan = file.Slice(Convert.ToInt32(header.SectionTablePosition + 40 * idx), 40);
-                var secTab = secTabSpan.ToArray();
-
                 sections.Add(
                     new CoffSection(
                         ReadSectionName(secTabSpan.Slice(0, 8), stringTab, encoding),
-                        BitConverter.ToUInt32(secTab, 8),
-                        BitConverter.ToUInt32(secTab, 12),
-                        BitConverter.ToUInt32(secTab, 16),
-                        BitConverter.ToUInt32(secTab, 20),
-                        BitConverter.ToUInt32(secTab, 24),
-                        BitConverter.ToUInt32(secTab, 28),
-                        BitConverter.ToUInt16(secTab, 32),
-                        BitConverter.ToUInt16(secTab, 34),
-                        BitConverter.ToUInt32(secTab, 36)));
+                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(8)),
+                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(12)),
+                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(16)),
+                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(20)),
+                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(24)),
+                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(28)),
+                        BinaryPrimitives.ReadUInt16LittleEndian(secTabSpan.Slice(32)),
+                        BinaryPrimitives.ReadUInt16LittleEndian(secTabSpan.Slice(34)),
+                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(36))));
             }
         }
 
@@ -62,17 +60,16 @@ public class CoffParser
             for (int idx = 0; idx < header.NumSymbols; idx++)
             {
                 var symTabSpan = file.Slice(Convert.ToInt32(header.SymbolTablePosition + 18 * idx), 18);
-                var symTab = symTabSpan.ToArray();
                 var name = ReadSymbolName(symTabSpan.Slice(0, 8), stringTab, encoding);
 
                 symbols.Add(
                     new CoffSymbol(
                         name,
-                        BitConverter.ToUInt32(symTab, 8),
-                        BitConverter.ToInt16(symTab, 12),
-                        BitConverter.ToUInt16(symTab, 14),
-                        symTab[16],
-                        symTab[17]));
+                        BinaryPrimitives.ReadUInt32LittleEndian(symTabSpan.Slice(8)),
+                        BinaryPrimitives.ReadInt16LittleEndian(symTabSpan.Slice(12)),
+                        BinaryPrimitives.ReadUInt16LittleEndian(symTabSpan.Slice(14)),
+                        symTabSpan[16],
+                        symTabSpan[17]));
             }
         }
 
@@ -97,24 +94,15 @@ public class CoffParser
     public static Span<byte> ReadRawData(Span<byte> file, CoffSection section) =>
         file.Slice(Convert.ToInt32(section.RawDataPosition), Convert.ToInt32(section.SectionSize));
 
-    private static CoffHeader ReadHeader(ReadOnlySpan<byte> header)
-    {
-        var magic = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(0, 2));
-        var nscns = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(2, 2));
-        var timdat = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(4, 4));
-        var symptr = BinaryPrimitives.ReadInt32LittleEndian(header.Slice(8, 4));
-        var nsyms = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(12, 4));
-        var opthdr = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(16, 2));
-        var flags = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(18, 2));
-        return new CoffHeader(
-            magic,
-            nscns,
-            timdat,
-            symptr,
-            nsyms,
-            opthdr,
-            flags);
-    }
+    private static CoffHeader ReadHeader(ReadOnlySpan<byte> header) =>
+        new CoffHeader(
+            BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(0, 2)),
+            BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(2, 2)),
+            BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(4, 4)),
+            BinaryPrimitives.ReadInt32LittleEndian(header.Slice(8, 4)),
+            BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(12, 4)),
+            BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(16, 2)),
+            BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(18, 2)));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ReadOnlySpan<byte> GetStringTable(ReadOnlySpan<byte> file, CoffHeader header)

--- a/CoffReader/CoffParser.cs
+++ b/CoffReader/CoffParser.cs
@@ -36,41 +36,37 @@ public class CoffParser
         var stringTab = GetStringTable(file, header);
 
         var sections = new List<CoffSection>();
+        for (int idx = 0; idx < header.NumSections; idx++)
         {
-            for (int idx = 0; idx < header.NumSections; idx++)
-            {
-                var secTabSpan = file.Slice(Convert.ToInt32(header.SectionTablePosition + 40 * idx), 40);
-                sections.Add(
-                    new CoffSection(
-                        ReadSectionName(secTabSpan.Slice(0, 8), stringTab, encoding),
-                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(8)),
-                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(12)),
-                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(16)),
-                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(20)),
-                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(24)),
-                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(28)),
-                        BinaryPrimitives.ReadUInt16LittleEndian(secTabSpan.Slice(32)),
-                        BinaryPrimitives.ReadUInt16LittleEndian(secTabSpan.Slice(34)),
-                        BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(36))));
-            }
+            var secTabSpan = file.Slice(Convert.ToInt32(header.SectionTablePosition + 40 * idx), 40);
+            sections.Add(
+                new CoffSection(
+                    ReadSectionName(secTabSpan.Slice(0, 8), stringTab, encoding),
+                    BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(8)),
+                    BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(12)),
+                    BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(16)),
+                    BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(20)),
+                    BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(24)),
+                    BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(28)),
+                    BinaryPrimitives.ReadUInt16LittleEndian(secTabSpan.Slice(32)),
+                    BinaryPrimitives.ReadUInt16LittleEndian(secTabSpan.Slice(34)),
+                    BinaryPrimitives.ReadUInt32LittleEndian(secTabSpan.Slice(36))));
         }
 
         var symbols = new List<CoffSymbol>();
+        for (int idx = 0; idx < header.NumSymbols; idx++)
         {
-            for (int idx = 0; idx < header.NumSymbols; idx++)
-            {
-                var symTabSpan = file.Slice(Convert.ToInt32(header.SymbolTablePosition + 18 * idx), 18);
-                var name = ReadSymbolName(symTabSpan.Slice(0, 8), stringTab, encoding);
+            var symTabSpan = file.Slice(Convert.ToInt32(header.SymbolTablePosition + 18 * idx), 18);
+            var name = ReadSymbolName(symTabSpan.Slice(0, 8), stringTab, encoding);
 
-                symbols.Add(
-                    new CoffSymbol(
-                        name,
-                        BinaryPrimitives.ReadUInt32LittleEndian(symTabSpan.Slice(8)),
-                        BinaryPrimitives.ReadInt16LittleEndian(symTabSpan.Slice(12)),
-                        BinaryPrimitives.ReadUInt16LittleEndian(symTabSpan.Slice(14)),
-                        symTabSpan[16],
-                        symTabSpan[17]));
-            }
+            symbols.Add(
+                new CoffSymbol(
+                    name,
+                    BinaryPrimitives.ReadUInt32LittleEndian(symTabSpan.Slice(8)),
+                    BinaryPrimitives.ReadInt16LittleEndian(symTabSpan.Slice(12)),
+                    BinaryPrimitives.ReadUInt16LittleEndian(symTabSpan.Slice(14)),
+                    symTabSpan[16],
+                    symTabSpan[17]));
         }
 
         var parsed = new CoffParsed(

--- a/CoffReader/CoffParser.cs
+++ b/CoffReader/CoffParser.cs
@@ -63,16 +63,13 @@ public class CoffParser
                     : _raw.GetString(symTab, 0, 8).Split('\0').First();
 
                 parsed.Symbols.Add(
-                    new CoffSymbol
-                    {
-                        Name = name,
-                        Value = BitConverter.ToUInt32(symTab, 8),
-                        SectionNumber = BitConverter.ToInt16(symTab, 12),
-                        SymbolType = BitConverter.ToUInt16(symTab, 14),
-                        StorageClass = symTab[16],
-                        NumAux = symTab[17],
-                    }
-                );
+                    new CoffSymbol(
+                        name,
+                        BitConverter.ToUInt32(symTab, 8),
+                        BitConverter.ToInt16(symTab, 12),
+                        BitConverter.ToUInt16(symTab, 14),
+                        symTab[16],
+                        symTab[17]));
             }
         }
 

--- a/CoffReader/CoffParser.cs
+++ b/CoffReader/CoffParser.cs
@@ -29,20 +29,17 @@ public class CoffParser
                 var secTab = file.Slice(Convert.ToInt32(header.SectionTablePosition + 40 * idx), 40).ToArray();
 
                 parsed.Sections.Add(
-                    new CoffSection
-                    {
-                        Name = _raw.GetString(secTab, 0, 8).Split('\0').First(),
-                        PhysicalAddress = BitConverter.ToUInt32(secTab, 8),
-                        VirtualAddress = BitConverter.ToUInt32(secTab, 12),
-                        SectionSize = BitConverter.ToUInt32(secTab, 16),
-                        RawDataPosition = BitConverter.ToUInt32(secTab, 20),
-                        RelocationPosition = BitConverter.ToUInt32(secTab, 24),
-                        LineNumberPosition = BitConverter.ToUInt32(secTab, 28),
-                        NumRelocations = BitConverter.ToUInt16(secTab, 32),
-                        NumLineNumbers = BitConverter.ToUInt16(secTab, 34),
-                        Flags = BitConverter.ToUInt32(secTab, 36),
-                    }
-                );
+                    new CoffSection(
+                        _raw.GetString(secTab, 0, 8).Split('\0').First(),
+                        BitConverter.ToUInt32(secTab, 8),
+                        BitConverter.ToUInt32(secTab, 12),
+                        BitConverter.ToUInt32(secTab, 16),
+                        BitConverter.ToUInt32(secTab, 20),
+                        BitConverter.ToUInt32(secTab, 24),
+                        BitConverter.ToUInt32(secTab, 28),
+                        BitConverter.ToUInt16(secTab, 32),
+                        BitConverter.ToUInt16(secTab, 34),
+                        BitConverter.ToUInt32(secTab, 36)));
             }
         }
 

--- a/CoffReader/CoffParser.cs
+++ b/CoffReader/CoffParser.cs
@@ -1,98 +1,94 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text;
-using System.Threading.Tasks;
 
-namespace CoffReader
+namespace CoffReader;
+
+/// <summary>
+/// COFF parser
+/// </summary>
+/// <see cref="http://delorie.com/djgpp/doc/coff/"/>
+public class CoffParser
 {
-    /// <summary>
-    /// COFF parser
-    /// </summary>
-    /// <see cref="http://delorie.com/djgpp/doc/coff/"/>
-    public class CoffParser
+    private static readonly Encoding _raw = Encoding.GetEncoding("latin1");
+
+    public static CoffParsed Parse(Span<byte> file)
     {
-        private static readonly Encoding _raw = Encoding.GetEncoding("latin1");
+        var header = file.Slice(0, 20).ToArray();
+        var f_magic = BitConverter.ToUInt16(header, 0);
+        var f_nscns = BitConverter.ToUInt16(header, 2);
+        var f_timdat = BitConverter.ToUInt32(header, 4);
+        var f_symptr = BitConverter.ToUInt32(header, 8);
+        var f_nsyms = BitConverter.ToUInt32(header, 12);
+        var f_opthdr = BitConverter.ToUInt16(header, 16);
+        var f_flags = BitConverter.ToUInt16(header, 18);
 
-        public static CoffParsed Parse(Span<byte> file)
+        var parsed = new CoffParsed
         {
-            var header = file.Slice(0, 20).ToArray();
-            var f_magic = BitConverter.ToUInt16(header, 0);
-            var f_nscns = BitConverter.ToUInt16(header, 2);
-            var f_timdat = BitConverter.ToUInt32(header, 4);
-            var f_symptr = BitConverter.ToUInt32(header, 8);
-            var f_nsyms = BitConverter.ToUInt32(header, 12);
-            var f_opthdr = BitConverter.ToUInt16(header, 16);
-            var f_flags = BitConverter.ToUInt16(header, 18);
+            Timestamp = f_timdat,
+            Magic = f_magic,
+            Flags = f_flags,
+        };
 
-            var parsed = new CoffParsed
+        {
+            for (int idx = 0; idx < f_nscns; idx++)
             {
-                Timestamp = f_timdat,
-                Magic = f_magic,
-                Flags = f_flags,
-            };
+                var secTab = file.Slice(Convert.ToInt32(20 + 40 * idx), 40).ToArray();
 
-            {
-                for (int idx = 0; idx < f_nscns; idx++)
-                {
-                    var secTab = file.Slice(Convert.ToInt32(20 + 40 * idx), 40).ToArray();
-
-                    parsed.Sections.Add(
-                        new CoffSection
-                        {
-                            Name = _raw.GetString(secTab, 0, 8).Split('\0').First(),
-                            PhysicalAddress = BitConverter.ToUInt32(secTab, 8),
-                            VirtualAddress = BitConverter.ToUInt32(secTab, 12),
-                            SectionSize = BitConverter.ToUInt32(secTab, 16),
-                            RawDataPosition = BitConverter.ToUInt32(secTab, 20),
-                            RelocationPosition = BitConverter.ToUInt32(secTab, 24),
-                            LineNumberPosition = BitConverter.ToUInt32(secTab, 28),
-                            NumRelocations = BitConverter.ToUInt16(secTab, 32),
-                            NumLineNumbers = BitConverter.ToUInt16(secTab, 34),
-                            Flags = BitConverter.ToUInt32(secTab, 36),
-                        }
-                    );
-                }
-            }
-
-            {
-                var ofsStringTab = Convert.ToInt32(f_symptr + 18 * f_nsyms);
-                var sizeStringTab = BitConverter.ToInt32(file.Slice(ofsStringTab, 4).ToArray(), 0);
-                var stringTab = _raw.GetString(
-                    file.Slice(ofsStringTab, Convert.ToInt32(sizeStringTab))
-                        .ToArray()
+                parsed.Sections.Add(
+                    new CoffSection
+                    {
+                        Name = _raw.GetString(secTab, 0, 8).Split('\0').First(),
+                        PhysicalAddress = BitConverter.ToUInt32(secTab, 8),
+                        VirtualAddress = BitConverter.ToUInt32(secTab, 12),
+                        SectionSize = BitConverter.ToUInt32(secTab, 16),
+                        RawDataPosition = BitConverter.ToUInt32(secTab, 20),
+                        RelocationPosition = BitConverter.ToUInt32(secTab, 24),
+                        LineNumberPosition = BitConverter.ToUInt32(secTab, 28),
+                        NumRelocations = BitConverter.ToUInt16(secTab, 32),
+                        NumLineNumbers = BitConverter.ToUInt16(secTab, 34),
+                        Flags = BitConverter.ToUInt32(secTab, 36),
+                    }
                 );
-                for (int idx = 0; idx < f_nsyms; idx++)
-                {
-                    var symTab = file.Slice(Convert.ToInt32(f_symptr + 18 * idx), 18).ToArray();
-                    var nameIsRef = BitConverter.ToInt32(symTab, 0) == 0;
-                    var nameRef = BitConverter.ToInt32(symTab, 0 + 4);
-                    var name = nameIsRef
-                        ? ((nameRef == 0)
-                            ? ""
-                            : stringTab.Substring(nameRef).Split('\0').First()
-                        )
-                        : _raw.GetString(symTab, 0, 8).Split('\0').First();
-
-                    parsed.Symbols.Add(
-                        new CoffSymbol
-                        {
-                            Name = name,
-                            Value = BitConverter.ToUInt32(symTab, 8),
-                            SectionNumber = BitConverter.ToInt16(symTab, 12),
-                            SymbolType = BitConverter.ToUInt16(symTab, 14),
-                            StorageClass = symTab[16],
-                            NumAux = symTab[17],
-                        }
-                    );
-                }
             }
-
-            return parsed;
         }
 
-        public static Span<byte> ReadRawData(Span<byte> file, CoffSection section) =>
-            file.Slice(Convert.ToInt32(section.RawDataPosition), Convert.ToInt32(section.SectionSize));
+        {
+            var ofsStringTab = Convert.ToInt32(f_symptr + 18 * f_nsyms);
+            var sizeStringTab = BitConverter.ToInt32(file.Slice(ofsStringTab, 4).ToArray(), 0);
+            var stringTab = _raw.GetString(
+                file.Slice(ofsStringTab, Convert.ToInt32(sizeStringTab))
+                    .ToArray()
+            );
+            for (int idx = 0; idx < f_nsyms; idx++)
+            {
+                var symTab = file.Slice(Convert.ToInt32(f_symptr + 18 * idx), 18).ToArray();
+                var nameIsRef = BitConverter.ToInt32(symTab, 0) == 0;
+                var nameRef = BitConverter.ToInt32(symTab, 0 + 4);
+                var name = nameIsRef
+                    ? ((nameRef == 0)
+                        ? ""
+                        : stringTab.Substring(nameRef).Split('\0').First()
+                    )
+                    : _raw.GetString(symTab, 0, 8).Split('\0').First();
+
+                parsed.Symbols.Add(
+                    new CoffSymbol
+                    {
+                        Name = name,
+                        Value = BitConverter.ToUInt32(symTab, 8),
+                        SectionNumber = BitConverter.ToInt16(symTab, 12),
+                        SymbolType = BitConverter.ToUInt16(symTab, 14),
+                        StorageClass = symTab[16],
+                        NumAux = symTab[17],
+                    }
+                );
+            }
+        }
+
+        return parsed;
     }
+
+    public static Span<byte> ReadRawData(Span<byte> file, CoffSection section) =>
+        file.Slice(Convert.ToInt32(section.RawDataPosition), Convert.ToInt32(section.SectionSize));
 }

--- a/CoffReader/CoffParser.cs
+++ b/CoffReader/CoffParser.cs
@@ -29,7 +29,18 @@ public class CoffParser
     /// <returns>The parsed file.</returns>
     public static CoffParsed Parse(ReadOnlySpan<byte> file)
     {
-        return Parse(file, DefaultEncoding);
+        return Parse(file, IsLittleEndian);
+    }
+
+    /// <summary>
+    /// Parses the COFF file using the default encoding for strings.
+    /// </summary>
+    /// <param name="file">The file data to parse.</param>
+    /// <param name="littleEndian">Parse the COFF file in little-endian format.</param>
+    /// <returns>The parsed file.</returns>
+    public static CoffParsed Parse(ReadOnlySpan<byte> file, bool littleEndian)
+    {
+        return Parse(file, DefaultEncoding, littleEndian);
     }
 
     /// <summary>
@@ -38,9 +49,19 @@ public class CoffParser
     /// <param name="file">The file data to parse.</param>
     /// <param name="encoding">The encoding for the strings.</param>
     /// <returns>The parsed file.</returns>
-    public static CoffParsed Parse(ReadOnlySpan<byte> file, Encoding encoding)
+    public static CoffParsed Parse(ReadOnlySpan<byte> file, Encoding encoding) =>
+        Parse(file, encoding, IsLittleEndian);
+
+    /// <summary>
+    /// Parses the COFF file using the given encoding for strings.
+    /// </summary>
+    /// <param name="file">The file data to parse.</param>
+    /// <param name="encoding">The encoding for the strings.</param>
+    /// <param name="littleEndian">Parse the COFF file in little-endian format.</param>
+    /// <returns>The parsed file.</returns>
+    public static CoffParsed Parse(ReadOnlySpan<byte> file, Encoding encoding, bool littleEndian)
     {
-        var (header, sections, symbols) = IsLittleEndian
+        var (header, sections, symbols) = littleEndian
             ? ParseLittleEndian(file, encoding)
             : ParseBigEndian(file, encoding);
 

--- a/CoffReader/CoffReader.csproj
+++ b/CoffReader/CoffReader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;netstandard2.0</TargetFrameworks>
 
     <PackageId>HiraokaHyperTools.CoffReader</PackageId>
     <Version>0.1.0</Version>
@@ -13,9 +13,16 @@
     <PackageProjectUrl>https://github.com/HiraokaHyperTools/CoffReader</PackageProjectUrl>
     <RepositoryUrl>https://github.com/HiraokaHyperTools/CoffReader.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <LangVersion>10.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/CoffReader/CoffReader.csproj
+++ b/CoffReader/CoffReader.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net461;net6.0;netstandard2.0</TargetFrameworks>
@@ -16,6 +16,7 @@
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,5 +25,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Memory" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\">
+      <Link>README.md</Link>
+    </None>
   </ItemGroup>
 </Project>

--- a/CoffReader/CoffSection.cs
+++ b/CoffReader/CoffSection.cs
@@ -1,24 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace CoffReader;
 
-namespace CoffReader
+public class CoffSection
 {
-    public class CoffSection
-    {
-        public string Name { get; set; }
-        public uint PhysicalAddress { get; set; }
-        public uint VirtualAddress { get; set; }
-        public uint SectionSize { get; set; }
-        public uint RawDataPosition { get; set; }
-        public uint RelocationPosition { get; set; }
-        public uint LineNumberPosition { get; set; }
-        public ushort NumRelocations { get; set; }
-        public ushort NumLineNumbers { get; set; }
-        public uint Flags { get; set; }
+    public string Name { get; set; }
+    public uint PhysicalAddress { get; set; }
+    public uint VirtualAddress { get; set; }
+    public uint SectionSize { get; set; }
+    public uint RawDataPosition { get; set; }
+    public uint RelocationPosition { get; set; }
+    public uint LineNumberPosition { get; set; }
+    public ushort NumRelocations { get; set; }
+    public ushort NumLineNumbers { get; set; }
+    public uint Flags { get; set; }
 
-        public override string ToString() => $"{Name}";
-    }
+    public override string ToString() => $"{Name}";
 }

--- a/CoffReader/CoffSection.cs
+++ b/CoffReader/CoffSection.cs
@@ -1,17 +1,16 @@
-﻿namespace CoffReader;
+﻿using System.Diagnostics;
 
-public class CoffSection
-{
-    public string Name { get; set; }
-    public uint PhysicalAddress { get; set; }
-    public uint VirtualAddress { get; set; }
-    public uint SectionSize { get; set; }
-    public uint RawDataPosition { get; set; }
-    public uint RelocationPosition { get; set; }
-    public uint LineNumberPosition { get; set; }
-    public ushort NumRelocations { get; set; }
-    public ushort NumLineNumbers { get; set; }
-    public uint Flags { get; set; }
+namespace CoffReader;
 
-    public override string ToString() => $"{Name}";
-}
+[DebuggerDisplay("{Name}")]
+public record CoffSection(
+    string Name,
+    uint PhysicalAddress,
+    uint VirtualAddress,
+    uint SectionSize,
+    uint RawDataPosition,
+    uint RelocationPosition,
+    uint LineNumberPosition,
+    ushort NumRelocations,
+    ushort NumLineNumbers,
+    uint Flags);

--- a/CoffReader/CoffSymbol.cs
+++ b/CoffReader/CoffSymbol.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace CoffReader;
 
@@ -8,5 +10,13 @@ public record CoffSymbol(
     uint Value,
     short SectionNumber,
     ushort SymbolType,
-    byte StorageClass,
-    byte NumAux);
+    byte StorageClass)
+{
+    [Obsolete("Use AuxiliaryRecords.Count instead.")]
+    public int NumAux => AuxiliaryRecords.Count;
+
+    /// <summary>
+    /// Gets the auxiliary records.
+    /// </summary>
+    public IReadOnlyList<byte[]> AuxiliaryRecords { get; init; } = Array.Empty<byte[]>();
+}

--- a/CoffReader/CoffSymbol.cs
+++ b/CoffReader/CoffSymbol.cs
@@ -1,13 +1,12 @@
-﻿namespace CoffReader;
+﻿using System.Diagnostics;
 
-public class CoffSymbol
-{
-    public string Name { get; set; }
-    public uint Value { get; set; }
-    public short SectionNumber { get; set; }
-    public ushort SymbolType { get; set; }
-    public byte StorageClass { get; set; }
-    public byte NumAux { get; internal set; }
+namespace CoffReader;
 
-    public override string ToString() => $"{Name}";
-}
+[DebuggerDisplay("{Name}")]
+public record CoffSymbol(
+    string Name,
+    uint Value,
+    short SectionNumber,
+    ushort SymbolType,
+    byte StorageClass,
+    byte NumAux);

--- a/CoffReader/CoffSymbol.cs
+++ b/CoffReader/CoffSymbol.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace CoffReader;
 
-namespace CoffReader
+public class CoffSymbol
 {
-    public class CoffSymbol
-    {
-        public string Name { get; set; }
-        public uint Value { get; set; }
-        public short SectionNumber { get; set; }
-        public ushort SymbolType { get; set; }
-        public byte StorageClass { get; set; }
-        public byte NumAux { get; internal set; }
+    public string Name { get; set; }
+    public uint Value { get; set; }
+    public short SectionNumber { get; set; }
+    public ushort SymbolType { get; set; }
+    public byte StorageClass { get; set; }
+    public byte NumAux { get; internal set; }
 
-        public override string ToString() => $"{Name}";
-    }
+    public override string ToString() => $"{Name}";
 }


### PR DESCRIPTION
# Changes (Non-breaking)

- Switch to C# 10
- Explicit support for .NET 4.6.1
- Use of file scoped namespaces
- Use of records for CoffSymbol, CoffSection and CoffParsed
- Switch default encoding to UTF-8
- Make default encoding configurable
- Reduce allocations
- Increase performance
- Allow reading little-endian COFF on big-endian systems

# Changes (breaking)

- Removed `ToString` for section and symbol
  - The record provides its own `ToString`
  - A `DebuggerDisplay` attribute was added instead

# Bug fixes

- Calculate the section table position using the optional header size
- Support long section names
- Support auxiliary records (avoid garbled symbols)
